### PR TITLE
Fix - Automation - Move e2e infra to canadaeast because of quota issues

### DIFF
--- a/.github/workflows/infra-e2e.yml
+++ b/.github/workflows/infra-e2e.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           az group create \
             --name ${{ steps.rg-name.outputs.rg_name }} \
-            --location eastus \
+            --location canadaeast \
             --tags \
               environment=ci \
               purpose=e2e-testing \


### PR DESCRIPTION
This pull request makes a minor update to the infrastructure end-to-end workflow configuration, changing the Azure resource group location from `eastus` to `canadaeast` in the `.github/workflows/infra-e2e.yml` file.